### PR TITLE
get rid of network name

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html page-var="5ffdc35e4f97e4bbf0ff3fb0" page-site="5fcf1a9eb645d039c0739542">
 <head>
   <meta charset="utf-8">
-  <title>Honeyswap - Decentralized Exchange built on xDai</title>
+  <title>Honeyswap - Decentralized Exchange</title>
   <meta content="Honeyswap is a decentralized exchange built on the xDai Chain, this enables users to experience fast and secure transactions with incredibly low fees.  Multiple tokens are available with which you can swap and add liquidity." name="description">
-  <meta content="Honeyswap - Decentralized Exchange built on xDai" property="og:title">
+  <meta content="Honeyswap - Decentralized Exchange" property="og:title">
   <meta content="Honeyswap is a decentralized exchange built on the xDai Chain, this enables users to experience fast and secure transactions with incredibly low fees.  Multiple tokens are available with which you can swap and add liquidity." property="og:description">
-  <meta content="Honeyswap - Decentralized Exchange built on xDai" property="twitter:title">
+  <meta content="Honeyswap - Decentralized Exchange" property="twitter:title">
   <meta content="Honeyswap is a decentralized exchange built on the xDai Chain, this enables users to experience fast and secure transactions with incredibly low fees.  Multiple tokens are available with which you can swap and add liquidity." property="twitter:description">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://honeyswap.org/images/twitter-card.png"/>
@@ -196,7 +196,7 @@
     <div class="container">
       <div class="flexbox hero-flexbox">
         <div class="left-block">
-          <h1 class="hero-heading">Honeyswap is a<br>Decentralized Exchange<br><span class="text-span">built on xDai.</span></h1>
+          <h1 class="hero-heading">Honeyswap is a<br>Decentralized Exchange</h1>
           <div class="div-block-6">
             <a href="https://app.honeyswap.org/" class="button w-button">Launch App</a>
             <a href="https://1hive.gitbook.io/1hive/projects/honeyswap" target="_blank" class="ghost-button w-button">Learn More</a>


### PR DESCRIPTION
I've changed the landing page to say "Honeyswap is a Decentralized Exchange" intead of Honeyswap is a Decentralized Exchange built on xDai"