### PR TITLE
Replace Honeyswap limo (broken) with https://app.honeyswap.org/

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
             <div class="text-block">Projects</div><img src="images/dropdown_icon.svg" loading="lazy" alt="">
           </div>
           <nav class="dropdown-list w-dropdown-list">
-            <a href="https://honeyswap.1hive.eth.limo/" class="dropdown-link w-dropdown-link">Honeyswap<br><span class="menu">Decentralized exchange</span><br></a>
+            <a href="https://app.honeyswap.org/" class="dropdown-link w-dropdown-link">Honeyswap<br><span class="menu">Decentralized exchange</span><br></a>
             <a href="https://1hive.org/" target="_blank" class="dropdown-link w-dropdown-link">Honeypot<br><span class="menu">The DAO Proposals</span></a>
             <a href="https://1hive.io" target="_blank" class="dropdown-link w-dropdown-link">Honeycomb<br><span class="menu">Yield farming &amp; staking!</span></a>
             <a href="https://celeste.1hive.org/" target="_blank" class="margin-block w-dropdown-link">Celeste<br><span class="menu">Subjective Oracle</span></a>
@@ -124,7 +124,7 @@
             <a href="https://1hive.gitbook.io/1hive/getting-started/contributing" target="_blank" class="margin-block w-dropdown-link">Contribute</a>
           </nav>
         </div>
-        <a href="https://honeyswap.1hive.eth.limo//" class="nav-link-5 w-nav-link">Launch App</a>
+        <a href="https://app.honeyswap.org//" class="nav-link-5 w-nav-link">Launch App</a>
       </nav>
       <div class="menu-button w-nav-button">
         <div class="icon-5 w-icon-nav-menu"></div>
@@ -141,7 +141,7 @@
             <div><img src="images/dropdown_icon.svg" loading="lazy" alt=""></div>
           </div>
           <nav class="dropdown-list w-dropdown-list">
-            <a href="https://honeyswap.1hive.eth.limo/" class="dropdown-link w-dropdown-link">Honeyswap<br><span class="menu">Decentralized exchange</span><br></a>
+            <a href="https://app.honeyswap.org/" class="dropdown-link w-dropdown-link">Honeyswap<br><span class="menu">Decentralized exchange</span><br></a>
             <a href="https://1hive.org/" target="_blank" class="dropdown-link w-dropdown-link">Honeypot<br><span class="menu">The DAO Proposals</span></a>
             <a href="https://1hive.io" target="_blank" class="dropdown-link w-dropdown-link">Honeycomb<br><span class="menu">Yield farming &amp; staking!</span></a>
             <a href="https://celeste.1hive.org/" target="_blank" class="margin-block w-dropdown-link">Celeste<br><span class="menu">Subjective Oracle</span></a>
@@ -187,7 +187,7 @@
             <a href="https://1hive.gitbook.io/1hive/getting-started/contributing" target="_blank" class="margin-block w-dropdown-link">Contribute</a>
           </nav>
         </div>
-        <a href="https://honeyswap.1hive.eth.limo//" class="nav-link-5 w-nav-link">Launch App</a>
+        <a href="https://app.honeyswap.org/" class="nav-link-5 w-nav-link">Launch App</a>
       </nav>
       <div class="menu-button w-nav-button">
         <div class="div-block-12"><img src="images/burger_menu.svg" loading="lazy" alt="" class="image-14"></div>
@@ -200,7 +200,7 @@
         <div class="left-block">
           <h1 class="hero-heading">Honeyswap is a<br>Decentralized Exchange</h1>
           <div class="div-block-6">
-            <a href="https://honeyswap.1hive.eth.limo//" class="button w-button">Launch App</a>
+            <a href="https://app.honeyswap.org//" class="button w-button">Launch App</a>
             <a href="https://1hive.gitbook.io/1hive/projects/honeyswap" target="_blank" class="ghost-button w-button">Learn More</a>
           </div>
         </div>
@@ -407,7 +407,7 @@
           </div>
           <div class="footer-column">
             <div class="footer-title">Projects</div>
-            <a href="https://honeyswap.1hive.eth.limo/" target="_blank" class="footer-link">Honeyswap</a>
+            <a href="https://app.honeyswap.org/" target="_blank" class="footer-link">Honeyswap</a>
             <a href="https://1hive.io" target="_blank" class="footer-link">Honeycomb</a>
             <a href="https://1hive.org/" target="_blank" class="footer-link">Honeypot</a>
             <a href="https://celeste.1hive.org/" target="_blank" class="footer-link">Celeste</a>


### PR DESCRIPTION
Creating this PR to quickly fix the redirection to honeyswap.1hive.eth.limo domain that is not currently working (neither pingable)